### PR TITLE
Feature/json schema

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -1,0 +1,150 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "chtop settings",
+    "description": "chtop settings\n",
+    "type": "object",
+    "properties": {
+        "theme": {
+            "title": "theme",
+            "description": "Theme settings",
+            "type": "object",
+            "properties": {
+                "border": {
+                    "title": "border",
+                    "description": "A border",
+                    "type": "string",
+                    "minLength": 1,
+                    "pattern": "[^ ]",
+                    "default": "violet"
+                },
+                "graph": {
+                    "title": "graphics",
+                    "description": "Graphics settings",
+                    "type": "object",
+                    "properties": {
+                        "color": {
+                            "title": "color",
+                            "description": "A color",
+                            "type": "string",
+                            "minLength": 1,
+                            "pattern": "[^ ]",
+                            "default": "red"
+                        },
+                        "height": {
+                            "title": "height",
+                            "description": "A height",
+                            "type": "integer",
+                            "exclusiveMinimum": 0,
+                            "default": 5
+                        },
+                        "precision": {
+                            "title": "precision",
+                            "description": "A precision",
+                            "type": "integer",
+                            "exclusiveMinimum": 0,
+                            "default": 1
+                        }
+                    },
+                    "minProperties": 1,
+                    "additionalProperties": false
+                }
+            },
+            "minProperties": 1,
+            "additionalProperties": false
+        },
+        "clickhousemetrics": {
+            "title": "clickhouse metrics",
+            "description": "clickhousemetrics metrics",
+            "type": "object",
+            "properties": {
+                "metrics": {
+                    "title": "metrics",
+                    "description": "A metric",
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "required": [
+                            "alias",
+                            "name"
+                        ],
+                        "properties": {
+                            "alias": {
+                                "title": "alias",
+                                "description": "An alias",
+                                "type": "string",
+                                "minLength": 1,
+                                "pattern": "[^ ]",
+                                "examples": [
+                                    "Total Queries"
+                                ]
+                            },
+                            "name": {
+                                "title": "name",
+                                "description": "A name",
+                                "type": "string",
+                                "minLength": 1,
+                                "pattern": "[^ ]",
+                                "examples": [
+                                    "ClickHouseProfileEvents_Query"
+                                ]
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "uniqueItems": false,
+                    "minItems": 1
+                }
+            },
+            "minProperties": 1,
+            "additionalProperties": false
+        },
+        "clickhousequeries": {
+            "title": "clickhouse queries",
+            "description": "clickhousemetrics queries",
+            "type": "object",
+            "properties": {
+                "metrics": {
+                    "title": "metrics",
+                    "description": "A metric",
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "required": [
+                            "name",
+                            "sql"
+                        ],
+                        "properties": {
+                            "name": {
+                                "title": "name",
+                                "description": "A name",
+                                "type": "string",
+                                "minLength": 1,
+                                "pattern": "[^ ]",
+                                "examples": [
+                                    "Number of Running Queries"
+                                ]
+                            },
+                            "sql": {
+                                "title": "sql",
+                                "description": "An SQL",
+                                "type": "string",
+                                "minLength": 1,
+                                "pattern": "[^ ]",
+                                "examples": [
+                                    "select count(*) from system.processes"
+                                ]
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "uniqueItems": false,
+                    "minItems": 1
+                }
+            },
+            "minProperties": 1,
+            "additionalProperties": false
+        }
+    },
+    "minProperties": 1,
+    "additionalProperties": false
+}

--- a/schema.json
+++ b/schema.json
@@ -1,17 +1,17 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "chtop settings",
-    "description": "chtop settings\n",
+    "description": "chtop settings\nhttps://github.com/chhetripradeep/chtop?tab=readme-ov-file#themes",
     "type": "object",
     "properties": {
         "theme": {
             "title": "theme",
-            "description": "Theme settings",
+            "description": "Theme settings\nhttps://github.com/chhetripradeep/chtop?tab=readme-ov-file#themes",
             "type": "object",
             "properties": {
                 "border": {
                     "title": "border",
-                    "description": "A border",
+                    "description": "A border\nhttps://github.com/chhetripradeep/chtop?tab=readme-ov-file#themes",
                     "type": "string",
                     "minLength": 1,
                     "pattern": "[^ ]",
@@ -19,12 +19,12 @@
                 },
                 "graph": {
                     "title": "graphics",
-                    "description": "Graphics settings",
+                    "description": "Graphics settings\nhttps://github.com/chhetripradeep/chtop?tab=readme-ov-file#themes",
                     "type": "object",
                     "properties": {
                         "color": {
                             "title": "color",
-                            "description": "A color",
+                            "description": "A color\nhttps://github.com/chhetripradeep/chtop?tab=readme-ov-file#themes",
                             "type": "string",
                             "minLength": 1,
                             "pattern": "[^ ]",
@@ -32,14 +32,14 @@
                         },
                         "height": {
                             "title": "height",
-                            "description": "A height",
+                            "description": "A height\nhttps://github.com/chhetripradeep/chtop?tab=readme-ov-file#themes",
                             "type": "integer",
                             "exclusiveMinimum": 0,
                             "default": 5
                         },
                         "precision": {
                             "title": "precision",
-                            "description": "A precision",
+                            "description": "A precision\nhttps://github.com/chhetripradeep/chtop?tab=readme-ov-file#themes",
                             "type": "integer",
                             "exclusiveMinimum": 0,
                             "default": 1
@@ -54,12 +54,12 @@
         },
         "clickhousemetrics": {
             "title": "clickhouse metrics",
-            "description": "clickhousemetrics metrics",
+            "description": "clickhousemetrics metrics\nhttps://github.com/chhetripradeep/chtop?tab=readme-ov-file#metrics",
             "type": "object",
             "properties": {
                 "metrics": {
                     "title": "metrics",
-                    "description": "A metric",
+                    "description": "A metric\nhttps://github.com/chhetripradeep/chtop?tab=readme-ov-file#metrics",
                     "type": "array",
                     "items": {
                         "type": "object",
@@ -70,7 +70,7 @@
                         "properties": {
                             "alias": {
                                 "title": "alias",
-                                "description": "An alias",
+                                "description": "An alias\nhttps://github.com/chhetripradeep/chtop?tab=readme-ov-file#metrics",
                                 "type": "string",
                                 "minLength": 1,
                                 "pattern": "[^ ]",
@@ -80,7 +80,7 @@
                             },
                             "name": {
                                 "title": "name",
-                                "description": "A name",
+                                "description": "A name\nhttps://github.com/chhetripradeep/chtop?tab=readme-ov-file#metrics",
                                 "type": "string",
                                 "minLength": 1,
                                 "pattern": "[^ ]",
@@ -100,12 +100,12 @@
         },
         "clickhousequeries": {
             "title": "clickhouse queries",
-            "description": "clickhousemetrics queries",
+            "description": "clickhousemetrics queries\nhttps://github.com/chhetripradeep/chtop?tab=readme-ov-file#metrics",
             "type": "object",
             "properties": {
                 "metrics": {
                     "title": "metrics",
-                    "description": "A metric",
+                    "description": "A metric\nhttps://github.com/chhetripradeep/chtop?tab=readme-ov-file#metrics",
                     "type": "array",
                     "items": {
                         "type": "object",
@@ -116,7 +116,7 @@
                         "properties": {
                             "name": {
                                 "title": "name",
-                                "description": "A name",
+                                "description": "A name\nhttps://github.com/chhetripradeep/chtop?tab=readme-ov-file#metrics",
                                 "type": "string",
                                 "minLength": 1,
                                 "pattern": "[^ ]",
@@ -126,7 +126,7 @@
                             },
                             "sql": {
                                 "title": "sql",
-                                "description": "An SQL",
+                                "description": "An SQL\nhttps://github.com/chhetripradeep/chtop?tab=readme-ov-file#metrics",
                                 "type": "string",
                                 "minLength": 1,
                                 "pattern": "[^ ]",


### PR DESCRIPTION
![image](https://github.com/chhetripradeep/chtop/assets/42812113/2d03b680-87ef-4815-af70-34c35f3d452a)

There are several possible ways of utilizing this schema ([YAML](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml) extension is required in VS Code to make them work):

- It can be referenced directly `# yaml-language-server: $schema={{schema url in this repository}}` in `~/.chtop.yaml`, this is a manual approach because requires user to put a full URL by hand.
- It can be put in [SchemaStore](https://github.com/SchemaStore/schemastore) and referenced there like [this](https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/markdownlint.json#L2). This approach ensures that whenever user edits `~/.chtop.yaml` they get the latest hints for it.


> If this PR is accepted this schema is referenced in [SchemaStore](https://github.com/SchemaStore/schemastore) to automatically enable validation for `~/.chtop.yaml`.

